### PR TITLE
Use dotted underlines for links

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -54,3 +54,7 @@ div.post-entry-title {
    display: block;
    height: 40px;
  }
+
+ a {
+   text-decoration: underline dotted;
+ }


### PR DESCRIPTION
![Screen Shot 2019-06-23 at 11 22 19](https://user-images.githubusercontent.com/910753/59974172-356f2980-95a9-11e9-8f65-a807a3e8993c.png)

This makes the links a bit clearer in a subtle way. See the above example.